### PR TITLE
Refactor quiz page into modular widgets

### DIFF
--- a/lib/presentation/modules/home_module/quiz/quiz_constants.dart
+++ b/lib/presentation/modules/home_module/quiz/quiz_constants.dart
@@ -1,0 +1,4 @@
+import 'package:flutter/material.dart';
+
+/// Common constants that are shared between quiz widgets.
+const Color quizPrimaryColor = Color(0xFF667eea);

--- a/lib/presentation/modules/home_module/quiz/quiz_page.dart
+++ b/lib/presentation/modules/home_module/quiz/quiz_page.dart
@@ -1,18 +1,24 @@
 import 'package:bilbank_app/presentation/components/main/custom_gradient_scaffold.dart';
-import 'package:bilbank_app/presentation/modules/home_module/quiz/widgets/spin_wheel_dialog.dart';
-import 'package:bilbank_app/presentation/modules/home_module/quiz/widgets/wheel_widgets.dart';
 import 'package:bilbank_app/presentation/navigation/app_page_keys.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
-import 'viewmodels/quiz_viewmodel.dart';
-import 'models/quiz_models.dart';
-import 'widgets/game_countdown_widget.dart';
-import 'widgets/question_widget.dart';
-import 'widgets/fortune_wheel_widget.dart';
+
 import '../../../../data/local_storage/local_storage.dart';
 import '../../../../data/local_storage/local_storage_impl.dart';
 import '../../../../data/local_storage/local_storage_keys.dart';
+import 'models/quiz_models.dart';
+import 'viewmodels/quiz_viewmodel.dart';
+import 'widgets/fortune_wheel_widget.dart';
+import 'widgets/game_countdown_widget.dart';
+import 'widgets/question_widget.dart';
+import 'widgets/quiz_error_bar.dart';
+import 'widgets/quiz_finished_screen.dart';
+import 'widgets/quiz_header.dart';
+import 'widgets/quiz_ranking_dialog.dart';
+import 'widgets/quiz_waiting_for_question.dart';
+import 'widgets/quiz_waiting_screen.dart';
+import 'widgets/spin_wheel_dialog.dart';
 
 class QuizPage extends StatefulWidget {
   final String roomId;
@@ -29,10 +35,58 @@ class QuizPage extends StatefulWidget {
 }
 
 class _QuizPageState extends State<QuizPage> {
+  late QuizViewModel _viewModel;
+  final LocalStorage _localStorage = LocalStorageImpl();
 
+  int? _lastWheelMultiplier;
+  bool _showMultiplierInfo = false;
+  bool _answerSent = false;
+  bool _isWheelSpinning = false;
+  int _wheelBalance = 15;
 
-    @override
-  Future<int?> showSpinWheelDialog(BuildContext context) {
+  @override
+  void initState() {
+    super.initState();
+    _viewModel = QuizViewModel.instance;
+    _setupRankingListener();
+    _initializeQuiz();
+  }
+
+  void _setupRankingListener() {
+    _viewModel.addListener(() {
+      final rankingData = _viewModel.quizData.rankingData;
+      if (rankingData != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          showQuizRankingDialog(
+            context: context,
+            rankingData: rankingData,
+          ).whenComplete(() {
+            _viewModel.clearRankingData();
+          });
+        });
+      }
+    });
+  }
+
+  Future<void> _initializeQuiz() async {
+    String finalToken = widget.token;
+    if (finalToken.isEmpty) {
+      print('Token boş, local storage\'dan alınıyor...');
+      finalToken = await _localStorage.getValue<String>(
+        LocalStorageKeys.accessToken,
+        '',
+      );
+      print(
+        'Local storage\'dan alınan token: '
+        '${finalToken.isNotEmpty ? "var" : "yok"}',
+      );
+    }
+
+    await _viewModel.initialize(finalToken);
+    await _viewModel.joinRoom(widget.roomId);
+  }
+
+  Future<int?> _showSpinWheelDialog(BuildContext context) {
     return showDialog<int>(
       context: context,
       useRootNavigator: true,
@@ -41,13 +95,9 @@ class _QuizPageState extends State<QuizPage> {
     );
   }
 
-  // Değişkenler sadece bir kez tanımlanmalı
-
-  int? _lastWheelMultiplier;
-  bool _showMultiplierInfo = false;
-
   void _handleWheelSpin() {
-    final currentMultiplier = _viewModel.quizData.currentQuestion?.multiplier ?? 1;
+    final currentMultiplier =
+        _viewModel.quizData.currentQuestion?.multiplier ?? 1;
     if (_isWheelSpinning || _wheelBalance <= 0 || _answerSent) return;
     if (currentMultiplier != 1) {
       setState(() {
@@ -84,8 +134,10 @@ class _QuizPageState extends State<QuizPage> {
                     _wheelBalance--;
                     _lastWheelMultiplier = selectedMultiplier;
                   });
-                  _viewModel.sendAnswer(true, wheelMultiplier: selectedMultiplier);
+                  _viewModel.sendAnswer(true,
+                      wheelMultiplier: selectedMultiplier);
                   Future.delayed(const Duration(seconds: 3), () {
+                    if (!mounted) return;
                     setState(() {
                       _lastWheelMultiplier = null;
                     });
@@ -101,53 +153,6 @@ class _QuizPageState extends State<QuizPage> {
       _isWheelSpinning = true;
     });
   }
-  late QuizViewModel _viewModel;
-  final LocalStorage _localStorage = LocalStorageImpl();
-  static const Color primaryColor = Color(0xFF667eea);
-
-  @override
-  void initState() {
-    super.initState();
-    _viewModel = QuizViewModel.instance;
-    _setupRankingListener();
-    _initializeQuiz();
-  }
-
-  void _setupRankingListener() {
-    _viewModel.addListener(() {
-      if (_viewModel.quizData.rankingData != null) {
-        WidgetsBinding.instance.addPostFrameCallback((_) {
-          _showRankingModal(context, _viewModel.quizData.rankingData!);
-          // Modal gösterildikten sonra ranking data'yı temizle
-          _viewModel.clearRankingData();
-        });
-      }
-    });
-  }
-
-  Future<void> _initializeQuiz() async {
-    String finalToken = widget.token;
-    if (finalToken.isEmpty) {
-      print('Token boş, local storage\'dan alınıyor...');
-      finalToken = await _localStorage.getValue<String>(
-        LocalStorageKeys.accessToken, 
-        '',
-      );
-      print('Local storage\'dan alınan token: ${finalToken.isNotEmpty ? "var" : "yok"}');
-    }
-    
-    await _viewModel.initialize(finalToken);
-    await _viewModel.joinRoom(widget.roomId);
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-  }
-
-  bool _answerSent = false;
-  bool _isWheelSpinning = false;
-  int _wheelBalance = 15;
 
   void _handleAnswer(bool answer) {
     if (!_answerSent) {
@@ -166,20 +171,32 @@ class _QuizPageState extends State<QuizPage> {
         body: SafeArea(
           child: Consumer<QuizViewModel>(
             builder: (context, viewModel, child) {
-              // Soru değiştiğinde butonları tekrar aktif et
               if (viewModel.quizData.currentQuestion != null && _answerSent) {
-                
-                  _answerSent = false;
-              
+                _answerSent = false;
               }
+
+              final canShowWheelDialog =
+                  !_isWheelSpinning && _wheelBalance > 0 && !_answerSent;
+
               return Column(
                 children: [
-                  _buildHeader(viewModel),
+                  QuizHeader(
+                    roomId: widget.roomId,
+                    score: viewModel.quizData.score,
+                    isSocketConnected: viewModel.isSocketConnected,
+                    wheelBalance: _wheelBalance,
+                    isWheelSpinning: _isWheelSpinning,
+                    onBack: () => context.go(AppPageKeys.home),
+                    onRankingTap: viewModel.getRanking,
+                    onWheelTap: canShowWheelDialog
+                        ? () => _showSpinWheelDialog(context)
+                        : null,
+                  ),
                   Expanded(
                     child: _buildContent(viewModel),
                   ),
                   if (viewModel.errorMessage != null)
-                    _buildErrorBar(viewModel.errorMessage!),
+                    QuizErrorBar(message: viewModel.errorMessage!),
                 ],
               );
             },
@@ -188,153 +205,6 @@ class _QuizPageState extends State<QuizPage> {
       ),
     );
   }
-
-  Widget _buildHeader(QuizViewModel viewModel) {
-  return Container(
-    padding: const EdgeInsets.all(20),
-    child: Column(
-      children: [
-        Row(
-          children: [
-            IconButton(
-              onPressed: (){
-                context.go(AppPageKeys.home);
-              },
-              icon: const Icon(
-                Icons.arrow_back_ios,
-                color: Colors.white,
-                size: 24,
-              ),
-            ),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const Text(
-                    'Quiz Oyunu',
-                    style: TextStyle(
-                      color: Colors.white,
-                      fontSize: 20,
-                      fontWeight: FontWeight.bold,
-                    ),
-                  ),
-                  Text(
-                    'Oda: ${widget.roomId}',
-                    style: const TextStyle(
-                      color: Colors.white70,
-                      fontSize: 14,
-                    ),
-                  ),
-                ],
-              ),
-            ),
-            if (viewModel.quizData.score > 0)
-              Container(
-                padding: const EdgeInsets.symmetric(
-                  horizontal: 12,
-                  vertical: 6,
-                ),
-                decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.2),
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Text(
-                  'Skor: ${viewModel.quizData.score}',
-                  style: const TextStyle(
-                    color: Colors.white,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-              ),
-            const SizedBox(width: 8),
-            IconButton(
-              onPressed: () => viewModel.getRanking(),
-              icon: const Icon(
-                Icons.leaderboard,
-                color: Colors.white,
-                size: 24,
-              ),
-              tooltip: 'Sıralama',
-            ),
-          ],
-        ),
-        const SizedBox(height: 10),
-        // Modern çark bakiyesi ve animasyon
-        Row(
-          children: [
-            GestureDetector(
-              onTap: _isWheelSpinning || _wheelBalance <= 0 || _answerSent ? null : () => showSpinWheelDialog(context),
-              child: AnimatedRotation(
-                turns: _isWheelSpinning ? 5 : 0,
-                duration: const Duration(seconds: 5),
-                child: Container(
-                  decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(_isWheelSpinning ? 0.3 : 0.15),
-                    borderRadius: BorderRadius.circular(12),
-                    boxShadow: _isWheelSpinning
-                        ? [BoxShadow(color: Colors.amber.withOpacity(0.4), blurRadius: 12, spreadRadius: 2)]
-                        : [],
-                  ),
-                  padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
-                  child: Row(
-                    children: [
-                      // Bu kısmı değiştirin:
-                      WheelWidget(
-                        isSpinning: _isWheelSpinning,
-                        size: 40,
-                      ),
-                      const SizedBox(width: 8),
-                      Text(
-                        'Çark: $_wheelBalance/15',
-                        style: TextStyle(
-                          color: _isWheelSpinning ? Colors.amber : Colors.white,
-                          fontWeight: FontWeight.bold,
-                          fontSize: 18,
-                        ),
-                      ),
-                      if (_isWheelSpinning)
-                        Padding(
-                          padding: const EdgeInsets.only(left: 8.0),
-                          child: SizedBox(
-                            width: 18,
-                            height: 18,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2.5,
-                              valueColor: AlwaysStoppedAnimation<Color>(Colors.amber),
-                            ),
-                          ),
-                        ),
-                    ],
-                  ),
-                ),
-              ),
-            ),
-            const SizedBox(width: 16),
-            // Bağlantı durumu
-            Icon(
-              viewModel.isSocketConnected 
-                  ? Icons.wifi 
-                  : Icons.wifi_off,
-              color: viewModel.isSocketConnected 
-                  ? Colors.greenAccent 
-                  : Colors.redAccent,
-              size: 16,
-            ),
-            const SizedBox(width: 6),
-            Text(
-              viewModel.isSocketConnected ? 'Bağlı' : 'Bağlanıyor...',
-              style: const TextStyle(
-                color: Colors.white70,
-                fontSize: 12,
-              ),
-            ),
-          ],
-        ),
-      ],
-    ),
-  );
-}
 
   Widget _buildContent(QuizViewModel viewModel) {
     final quizData = viewModel.quizData;
@@ -346,10 +216,11 @@ class _QuizPageState extends State<QuizPage> {
             seconds: quizData.countdown,
             roomName: widget.roomId,
           );
-        } else {
-          return _buildWaitingScreen();
         }
-
+        return QuizWaitingScreen(
+          isSocketConnected: viewModel.isSocketConnected,
+          onRetryConnection: viewModel.retryConnection,
+        );
       case QuizState.playing:
         if (quizData.hasQuestion) {
           return QuestionWidget(
@@ -360,420 +231,26 @@ class _QuizPageState extends State<QuizPage> {
             answerSent: _answerSent,
             wheelBalance: _wheelBalance,
             isWheelSpinning: _isWheelSpinning,
-            onWheelTap: _answerSent || _isWheelSpinning || _wheelBalance <= 0 ? null : _handleWheelSpin,
+            onWheelTap: _answerSent || _isWheelSpinning || _wheelBalance <= 0
+                ? null
+                : _handleWheelSpin,
             wheelMultiplierBadge: _lastWheelMultiplier,
             showMultiplierInfo: _showMultiplierInfo,
           );
-        } else {
-          return _buildWaitingForQuestionScreen();
         }
-
+        return const QuizWaitingForQuestion();
       case QuizState.finished:
-        return _buildFinishedScreen(viewModel);
-    }
-  }
-
-  Widget _buildWaitingScreen() {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          Consumer<QuizViewModel>(
-            builder: (context, viewModel, child) {
-              return Column(
-                children: [
-                  if (viewModel.isSocketConnected)
-                    const Icon(
-                      Icons.wifi,
-                      color: Colors.green,
-                      size: 32,
-                    )
-                  else
-                    const Icon(
-                      Icons.wifi_off,
-                      color: Colors.red,
-                      size: 32,
-                    ),
-                  const SizedBox(height: 8),
-                  Text(
-                    viewModel.isSocketConnected ? 'Bağlantı Kuruldu' : 'Bağlantı Bekleniyor...',
-                    style: TextStyle(
-                      color: viewModel.isSocketConnected ? Colors.green : Colors.orange,
-                      fontSize: 14,
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                ],
-              );
-            },
-          ),
-          const SizedBox(height: 20),
-          const CircularProgressIndicator(
-            color: Colors.white,
-          ),
-          const SizedBox(height: 20),
-          const Text(
-            'Oyun başlaması bekleniyor...',
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: 18,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-          const SizedBox(height: 10),
-          const Text(
-            'Minimum katılımcı sayısı sağlandığında oyun başlayacak',
-            style: TextStyle(
-              color: Colors.white70,
-            ),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 20),
-          Consumer<QuizViewModel>(
-            builder: (context, viewModel, child) {
-              if (!viewModel.isSocketConnected) {
-                return ElevatedButton.icon(
-                  onPressed: () => viewModel.retryConnection(),
-                  icon: const Icon(Icons.refresh),
-                  label: const Text('Bağlantıyı Yenile'),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.white,
-                    foregroundColor: primaryColor,
-                  ),
-                );
-              }
-              return const SizedBox.shrink();
-            },
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildWaitingForQuestionScreen() {
-    return const Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          CircularProgressIndicator(
-            color: Colors.white,
-          ),
-          SizedBox(height: 20),
-          Text(
-            'Sonraki soru bekleniyor...',
-            style: TextStyle(
-              color: Colors.white,
-              fontSize: 18,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildFinishedScreen(QuizViewModel viewModel) {
-    return Center(
-      child: Container(
-        margin: const EdgeInsets.all(20),
-        padding: const EdgeInsets.all(24),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(16),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.1),
-              blurRadius: 10,
-              offset: const Offset(0, 5),
-            ),
-          ],
-        ),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            const Icon(
-              Icons.emoji_events,
-              size: 60,
-              color: Colors.amber,
-            ),
-            const SizedBox(height: 16),
-            const Text(
-              'Oyun Bitti!',
-              style: TextStyle(
-                color: Colors.amber, // Changed to a constant color
-                fontWeight: FontWeight.bold,
-              ),
-            ),
-            const SizedBox(height: 16),
-            Container(
-              padding: const EdgeInsets.all(16),
-              decoration: BoxDecoration(
-                color: primaryColor.withOpacity(0.1),
-                borderRadius: BorderRadius.circular(12),
-              ),
-              child: Column(
-                children: [
-                  const Text(
-                    'Final Skorunuz',
-                    style: TextStyle(
-                      fontWeight: FontWeight.w500,
-                    ),
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    '${viewModel.quizData.score}',
-                    style: TextStyle(
-                      fontSize: 32,
-                      fontWeight: FontWeight.bold,
-                      color: primaryColor,
-                    ),
-                  ),
-                  if (viewModel.quizData.rank > 0) ...[
-                    const SizedBox(height: 8),
-                    Text(
-                      'Sıralama: #${viewModel.quizData.rank}',
-                      style: TextStyle(
-                        fontSize: 16,
-                        color: Colors.grey[600],
-                      ),
-                    ),
-                  ],
-                ],
-              ),
-            ),
-            const SizedBox(height: 24),
-            Row(
-              children: [
-                Expanded(
-                  child: ElevatedButton.icon(
-                    onPressed: () => viewModel.retryConnection(),
-                    icon: const Icon(Icons.refresh),
-                    label: const Text('Tekrar Oyna'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: primaryColor.withOpacity(0.2),
-                      foregroundColor: primaryColor,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: ElevatedButton.icon(
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                    icon: const Icon(Icons.home),
-                    label: const Text('Ana Sayfa'),
-                    style: ElevatedButton.styleFrom(
-                      backgroundColor: primaryColor,
-                      foregroundColor: Colors.white,
-                    ),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-
-  Widget _buildErrorBar(String message) {
-    return Container(
-      width: double.infinity,
-      padding: const EdgeInsets.all(16),
-      color: Colors.red.withOpacity(0.9),
-      child: Row(
-        children: [
-          const Icon(
-            Icons.error_outline,
-            color: Colors.white,
-          ),
-          const SizedBox(width: 12),
-          Expanded(
-            child: Text(
-              message,
-              style: const TextStyle(
-                color: Colors.white,
-                fontWeight: FontWeight.w500,
-              ),
-            ),
-          ),
-        ],
-      ),
-    );
-  }
-
-  void _showRankingModal(BuildContext context, RankingData rankingData) {
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return Dialog(
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20),
-          ),
-          child: Container(
-            padding: const EdgeInsets.all(20),
-            decoration: BoxDecoration(
-              borderRadius: BorderRadius.circular(20),
-              gradient: const LinearGradient(
-                begin: Alignment.topLeft,
-                end: Alignment.bottomRight,
-                colors: [Color(0xFF667eea), Color(0xFF764ba2)],
-              ),
-            ),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: [
-                // Header
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    const Text(
-                      '🏆 Sıralama',
-                      style: TextStyle(
-                        color: Colors.white,
-                        fontSize: 20,
-                        fontWeight: FontWeight.bold,
-                      ),
-                    ),
-                    IconButton(
-                      onPressed: () {
-                        Navigator.of(context).pop();
-                        _viewModel.clearRankingData();
-                      },
-                      icon: const Icon(
-                        Icons.close,
-                        color: Colors.white,
-                      ),
-                    ),
-                  ],
-                ),
-                const SizedBox(height: 10),
-                
-                // My Rank
-                if (rankingData.myRank != null)
-                  Container(
-                    width: double.infinity,
-                    padding: const EdgeInsets.all(12),
-                    decoration: BoxDecoration(
-                      color: Colors.white.withOpacity(0.2),
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    child: Text(
-                      rankingData.myRank!.displayText,
-                      style: const TextStyle(
-                        color: Colors.white,
-                        fontSize: 16,
-                        fontWeight: FontWeight.bold,
-                      ),
-                      textAlign: TextAlign.center,
-                    ),
-                  ),
-                
-                const SizedBox(height: 16),
-                
-                // Rankings List
-                const Text(
-                  'İlk 10 Sıralama',
-                  style: TextStyle(
-                    color: Colors.white,
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                const SizedBox(height: 10),
-                
-                Container(
-                  constraints: const BoxConstraints(maxHeight: 300),
-                  child: ListView.builder(
-                    shrinkWrap: true,
-                    itemCount: rankingData.rankings.length,
-                    itemBuilder: (context, index) {
-                      final item = rankingData.rankings[index];
-                      return Container(
-                        margin: const EdgeInsets.only(bottom: 8),
-                        padding: const EdgeInsets.all(12),
-                        decoration: BoxDecoration(
-                          color: item.isMe 
-                              ? Colors.yellow.withOpacity(0.3)
-                              : Colors.white.withOpacity(0.1),
-                          borderRadius: BorderRadius.circular(10),
-                          border: item.isMe 
-                              ? Border.all(color: Colors.yellow, width: 2)
-                              : null,
-                        ),
-                        child: Row(
-                          children: [
-                            // Rank
-                            Container(
-                              width: 30,
-                              height: 30,
-                              decoration: BoxDecoration(
-                                color: _getRankColor(item.rank),
-                                borderRadius: BorderRadius.circular(15),
-                              ),
-                              child: Center(
-                                child: Text(
-                                  '${item.rank}',
-                                  style: const TextStyle(
-                                    color: Colors.white,
-                                    fontWeight: FontWeight.bold,
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ),
-                            ),
-                            const SizedBox(width: 12),
-                            
-                            // Username
-                            Expanded(
-                              child: Text(
-                                item.username,
-                                style: TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 14,
-                                  fontWeight: item.isMe 
-                                      ? FontWeight.bold 
-                                      : FontWeight.normal,
-                                ),
-                              ),
-                            ),
-                            
-                            // Score
-                            Text(
-                              '${item.score} puan',
-                              style: TextStyle(
-                                color: Colors.white,
-                                fontSize: 14,
-                                fontWeight: item.isMe 
-                                    ? FontWeight.bold 
-                                    : FontWeight.normal,
-                              ),
-                            ),
-                          ],
-                        ),
-                      );
-                    },
-                  ),
-                ),
-              ],
-            ),
-          ),
+        return QuizFinishedScreen(
+          score: quizData.score,
+          rank: quizData.rank,
+          onPlayAgain: viewModel.retryConnection,
+          onReturnHome: () => Navigator.of(context).pop(),
         );
-      },
-    );
+    }
   }
 
-  Color _getRankColor(int rank) {
-    switch (rank) {
-      case 1:
-        return Colors.amber; // Gold
-      case 2:
-        return Colors.grey[300]!; // Silver
-      case 3:
-        return Colors.orange[300]!; // Bronze
-      default:
-        return Colors.blue[300]!;
-    }
+  @override
+  void dispose() {
+    super.dispose();
   }
 }

--- a/lib/presentation/modules/home_module/quiz/widgets/quiz_error_bar.dart
+++ b/lib/presentation/modules/home_module/quiz/widgets/quiz_error_bar.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+
+class QuizErrorBar extends StatelessWidget {
+  const QuizErrorBar({super.key, required this.message});
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      color: Colors.red.withOpacity(0.9),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.error_outline,
+            color: Colors.white,
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              message,
+              style: const TextStyle(
+                color: Colors.white,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/modules/home_module/quiz/widgets/quiz_finished_screen.dart
+++ b/lib/presentation/modules/home_module/quiz/widgets/quiz_finished_screen.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+import '../quiz_constants.dart';
+
+class QuizFinishedScreen extends StatelessWidget {
+  const QuizFinishedScreen({
+    super.key,
+    required this.score,
+    required this.rank,
+    required this.onPlayAgain,
+    required this.onReturnHome,
+  });
+
+  final int score;
+  final int rank;
+  final VoidCallback onPlayAgain;
+  final VoidCallback onReturnHome;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        margin: const EdgeInsets.all(20),
+        padding: const EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 10,
+              offset: const Offset(0, 5),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.emoji_events,
+              size: 60,
+              color: Colors.amber,
+            ),
+            const SizedBox(height: 16),
+            const Text(
+              'Oyun Bitti!',
+              style: TextStyle(
+                color: Colors.amber,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: quizPrimaryColor.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Column(
+                children: [
+                  const Text(
+                    'Final Skorunuz',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    '$score',
+                    style: const TextStyle(
+                      fontSize: 32,
+                      fontWeight: FontWeight.bold,
+                      color: quizPrimaryColor,
+                    ),
+                  ),
+                  if (rank > 0) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      'Sıralama: #$rank',
+                      style: TextStyle(
+                        fontSize: 16,
+                        color: Colors.grey[600],
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            Row(
+              children: [
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: onPlayAgain,
+                    icon: const Icon(Icons.refresh),
+                    label: const Text('Tekrar Oyna'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: quizPrimaryColor.withOpacity(0.2),
+                      foregroundColor: quizPrimaryColor,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: ElevatedButton.icon(
+                    onPressed: onReturnHome,
+                    icon: const Icon(Icons.home),
+                    label: const Text('Ana Sayfa'),
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: quizPrimaryColor,
+                      foregroundColor: Colors.white,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/modules/home_module/quiz/widgets/quiz_header.dart
+++ b/lib/presentation/modules/home_module/quiz/widgets/quiz_header.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+
+import 'wheel_widgets.dart';
+
+class QuizHeader extends StatelessWidget {
+  const QuizHeader({
+    super.key,
+    required this.roomId,
+    required this.score,
+    required this.isSocketConnected,
+    required this.wheelBalance,
+    required this.isWheelSpinning,
+    this.onBack,
+    this.onRankingTap,
+    this.onWheelTap,
+  });
+
+  final String roomId;
+  final int score;
+  final bool isSocketConnected;
+  final int wheelBalance;
+  final bool isWheelSpinning;
+  final VoidCallback? onBack;
+  final VoidCallback? onRankingTap;
+  final VoidCallback? onWheelTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final bool canSpinWheel = onWheelTap != null;
+
+    return Container(
+      padding: const EdgeInsets.all(20),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              IconButton(
+                onPressed: onBack,
+                icon: const Icon(
+                  Icons.arrow_back_ios,
+                  color: Colors.white,
+                  size: 24,
+                ),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Quiz Oyunu',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 20,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    Text(
+                      'Oda: $roomId',
+                      style: const TextStyle(
+                        color: Colors.white70,
+                        fontSize: 14,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              if (score > 0)
+                Container(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 12,
+                    vertical: 6,
+                  ),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.2),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Text(
+                    'Skor: $score',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+              const SizedBox(width: 8),
+              IconButton(
+                onPressed: onRankingTap,
+                icon: const Icon(
+                  Icons.leaderboard,
+                  color: Colors.white,
+                  size: 24,
+                ),
+                tooltip: 'Sıralama',
+              ),
+            ],
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              GestureDetector(
+                onTap: canSpinWheel ? onWheelTap : null,
+                child: AnimatedRotation(
+                  turns: isWheelSpinning ? 5 : 0,
+                  duration: const Duration(seconds: 5),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      color: Colors.white.withOpacity(
+                        isWheelSpinning ? 0.3 : 0.15,
+                      ),
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: isWheelSpinning
+                          ? [
+                              BoxShadow(
+                                color: Colors.amber.withOpacity(0.4),
+                                blurRadius: 12,
+                                spreadRadius: 2,
+                              ),
+                            ]
+                          : [],
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 10,
+                      vertical: 6,
+                    ),
+                    child: Row(
+                      children: [
+                        WheelWidget(
+                          isSpinning: isWheelSpinning,
+                          size: 40,
+                        ),
+                        const SizedBox(width: 8),
+                        Text(
+                          'Çark: $wheelBalance/15',
+                          style: TextStyle(
+                            color: isWheelSpinning
+                                ? Colors.amber
+                                : Colors.white,
+                            fontWeight: FontWeight.bold,
+                            fontSize: 18,
+                          ),
+                        ),
+                        if (isWheelSpinning)
+                          const Padding(
+                            padding: EdgeInsets.only(left: 8.0),
+                            child: SizedBox(
+                              width: 18,
+                              height: 18,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2.5,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                  Colors.amber,
+                                ),
+                              ),
+                            ),
+                          ),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 16),
+              Icon(
+                isSocketConnected ? Icons.wifi : Icons.wifi_off,
+                color: isSocketConnected ? Colors.greenAccent : Colors.redAccent,
+                size: 16,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                isSocketConnected ? 'Bağlı' : 'Bağlanıyor...',
+                style: const TextStyle(
+                  color: Colors.white70,
+                  fontSize: 12,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/modules/home_module/quiz/widgets/quiz_ranking_dialog.dart
+++ b/lib/presentation/modules/home_module/quiz/widgets/quiz_ranking_dialog.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+
+import '../models/quiz_models.dart';
+
+Future<void> showQuizRankingDialog({
+  required BuildContext context,
+  required RankingData rankingData,
+  VoidCallback? onDialogDismissed,
+}) async {
+  await showDialog<void>(
+    context: context,
+    builder: (dialogContext) => QuizRankingDialog(
+      rankingData: rankingData,
+    ),
+  );
+
+  onDialogDismissed?.call();
+}
+
+class QuizRankingDialog extends StatelessWidget {
+  const QuizRankingDialog({
+    super.key,
+    required this.rankingData,
+  });
+
+  final RankingData rankingData;
+
+  @override
+  Widget build(BuildContext context) {
+    return Dialog(
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(20),
+          gradient: const LinearGradient(
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+            colors: [Color(0xFF667eea), Color(0xFF764ba2)],
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  '🏆 Sıralama',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 20,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                IconButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  icon: const Icon(
+                    Icons.close,
+                    color: Colors.white,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 10),
+            if (rankingData.myRank != null)
+              Container(
+                width: double.infinity,
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  rankingData.myRank!.displayText,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            const SizedBox(height: 16),
+            const Text(
+              'İlk 10 Sıralama',
+              style: TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 10),
+            Container(
+              constraints: const BoxConstraints(maxHeight: 300),
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: rankingData.rankings.length,
+                itemBuilder: (context, index) {
+                  final item = rankingData.rankings[index];
+                  return Container(
+                    margin: const EdgeInsets.only(bottom: 8),
+                    padding: const EdgeInsets.all(12),
+                    decoration: BoxDecoration(
+                      color: item.isMe
+                          ? Colors.yellow.withOpacity(0.3)
+                          : Colors.white.withOpacity(0.1),
+                      borderRadius: BorderRadius.circular(10),
+                      border: item.isMe
+                          ? Border.all(color: Colors.yellow, width: 2)
+                          : null,
+                    ),
+                    child: Row(
+                      children: [
+                        Container(
+                          width: 30,
+                          height: 30,
+                          decoration: BoxDecoration(
+                            color: _rankColor(item.rank),
+                            borderRadius: BorderRadius.circular(15),
+                          ),
+                          child: Center(
+                            child: Text(
+                              '${item.rank}',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontWeight: FontWeight.bold,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: Text(
+                            item.username,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 14,
+                              fontWeight: item.isMe
+                                  ? FontWeight.bold
+                                  : FontWeight.normal,
+                            ),
+                          ),
+                        ),
+                        Text(
+                          '${item.score} puan',
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 14,
+                            fontWeight: item.isMe
+                                ? FontWeight.bold
+                                : FontWeight.normal,
+                          ),
+                        ),
+                      ],
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+Color _rankColor(int rank) {
+  switch (rank) {
+    case 1:
+      return Colors.amber;
+    case 2:
+      return Colors.grey[300]!;
+    case 3:
+      return Colors.orange[300]!;
+    default:
+      return Colors.blue[300]!;
+  }
+}

--- a/lib/presentation/modules/home_module/quiz/widgets/quiz_waiting_for_question.dart
+++ b/lib/presentation/modules/home_module/quiz/widgets/quiz_waiting_for_question.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+
+class QuizWaitingForQuestion extends StatelessWidget {
+  const QuizWaitingForQuestion({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          CircularProgressIndicator(
+            color: Colors.white,
+          ),
+          SizedBox(height: 20),
+          Text(
+            'Sonraki soru bekleniyor...',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/modules/home_module/quiz/widgets/quiz_waiting_screen.dart
+++ b/lib/presentation/modules/home_module/quiz/widgets/quiz_waiting_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+import '../quiz_constants.dart';
+
+class QuizWaitingScreen extends StatelessWidget {
+  const QuizWaitingScreen({
+    super.key,
+    required this.isSocketConnected,
+    required this.onRetryConnection,
+  });
+
+  final bool isSocketConnected;
+  final VoidCallback onRetryConnection;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            isSocketConnected ? Icons.wifi : Icons.wifi_off,
+            color: isSocketConnected ? Colors.green : Colors.red,
+            size: 32,
+          ),
+          const SizedBox(height: 8),
+          Text(
+            isSocketConnected ? 'Bağlantı Kuruldu' : 'Bağlantı Bekleniyor...',
+            style: TextStyle(
+              color: isSocketConnected ? Colors.green : Colors.orange,
+              fontSize: 14,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 20),
+          const CircularProgressIndicator(
+            color: Colors.white,
+          ),
+          const SizedBox(height: 20),
+          const Text(
+            'Oyun başlaması bekleniyor...',
+            style: TextStyle(
+              color: Colors.white,
+              fontSize: 18,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 10),
+          const Text(
+            'Minimum katılımcı sayısı sağlandığında oyun başlayacak',
+            style: TextStyle(
+              color: Colors.white70,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 20),
+          if (!isSocketConnected)
+            ElevatedButton.icon(
+              onPressed: onRetryConnection,
+              icon: const Icon(Icons.refresh),
+              label: const Text('Bağlantıyı Yenile'),
+              style: ElevatedButton.styleFrom(
+                backgroundColor: Colors.white,
+                foregroundColor: quizPrimaryColor,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- refactor the quiz page to delegate layout to modular widgets and simplify the state class
- add shared quiz UI helpers including constants, header, waiting/finished screens, error bar, and ranking dialog components

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d42524e4d8832d8508adeb412654e9